### PR TITLE
Using setState to render the view

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -30,7 +30,7 @@
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
 
-  <Target Name="PaketRestore" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" >
+  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" >
 
     <!-- Step 1 Check if lockfile is properly restored -->
     <PropertyGroup>
@@ -38,9 +38,24 @@
       <NoWarn>$(NoWarn);NU1603</NoWarn>
     </PropertyGroup>
 
+    <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
+    <PropertyGroup>
+        <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+        <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+    </PropertyGroup>
+
+    <!-- If shasum and awk exist get the hashes -->
+    <Exec Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
+    </Exec>
+    <Exec Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
+    </Exec>
+
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
-      <PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
-      <PaketRestoreLockFileHash>$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
+      <!-- if no hash has been done yet fall back to just reading in the files and comparing them -->
+      <PaketRestoreCachedHash Condition=" '$(PaketRestoreCachedHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
+      <PaketRestoreLockFileHash Condition=" '$(PaketRestoreLockFileHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
@@ -88,7 +103,7 @@
     <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
 
     <!-- This shouldn't actually happen, but just to be sure. -->
-    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' " Text="A paket file for the framework '$(TargetFramework)' is missing. Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' AND '$(ResolveNuGetPackages)' != 'False' " Text="Paket file '$(PaketResolvedFilePath)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
     <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
     <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
@@ -136,22 +151,29 @@
   </Target>
 
   <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
+    <ItemGroup>
+      <_NuspecFilesNewLocation Include="$(BaseIntermediateOutputPath)$(Configuration)\*.nuspec"/>
+    </ItemGroup>
+
     <PropertyGroup>
       <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
       <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
       <UseNewPack>false</UseNewPack>
       <UseNewPack Condition=" '$(NuGetToolVersion)' != '4.0.0' ">true</UseNewPack>
+      <AdjustedNuspecOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</AdjustedNuspecOutputPath>
+      <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(BaseIntermediateOutputPath)</AdjustedNuspecOutputPath>
     </PropertyGroup>
 
     <ItemGroup>
-      <_NuspecFiles Include="$(BaseIntermediateOutputPath)*.nuspec"/>
+      <_NuspecFiles Include="$(AdjustedNuspecOutputPath)\*.nuspec"/>
     </ItemGroup>
 
     <Exec Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' Condition="@(_NuspecFiles) != ''" />
 
     <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
-    </ConvertToAbsolutePath>
+    </ConvertToAbsolutePath>      
+        
 
     <!-- Call Pack -->
     <PackTask Condition="$(UseNewPack)"
@@ -188,7 +210,7 @@
               Serviceable="$(Serviceable)"
               FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(BaseIntermediateOutputPath)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
               BuildOutputFolder="$(BuildOutputTargetFolder)"
               ContentTargetFolders="$(ContentTargetFolders)"
@@ -230,7 +252,7 @@
               Serviceable="$(Serviceable)"
               AssemblyReferences="@(_References)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(BaseIntermediateOutputPath)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
               BuildOutputFolder="$(BuildOutputTargetFolder)"
               ContentTargetFolders="$(ContentTargetFolders)"

--- a/src/react.fs
+++ b/src/react.fs
@@ -3,24 +3,53 @@ namespace Elmish.React
 open System
 open Fable.Import.React
 open Fable.Core
+open FSharp
+open Elmish
+open Fable.Core.JsInterop
+open Fable.Import.React
 
+module AppComponents =
+    type [<Pojo>] AppState = {
+        render : unit -> ReactElement
+    }
+
+    type [<Pojo>] AppProps = {
+        getInternalSetState: (AppState -> unit) -> unit
+    }
+
+    type App(props) as this =
+        inherit Component<AppProps, AppState>(props)
+
+        do this.setInitState { render = fun _ -> Unchecked.defaultof<ReactElement> }
+        do (props.getInternalSetState this.setState)
+
+        member this.render () =
+            this.state.render()
+
+    let inline app p c = Fable.Helpers.React.com<App, AppProps, AppState> p c
 [<RequireQualifiedAccess>]
 module Program =
-    open Fable.Import.Browser
+    open Fable.Import
+    open AppComponents
     module R = Fable.Helpers.React
+
+    // global setInternalState should stay in top level, otherwise hmr won't working.
+    let mutable private setInternalState: (AppState -> unit) option = None
+
 
     /// Setup rendering of root React component inside html element identified by placeholderId
     let withReact placeholderId (program:Elmish.Program<_,_,_,_>) =
-        let mutable lastRequest = None
         let setState model dispatch =
-            match lastRequest with
-            | Some r -> window.cancelAnimationFrame r
-            | _ -> ()
-
-            lastRequest <- Some (window.requestAnimationFrame (fun _ -> 
-                Fable.Import.ReactDom.render(
-                    lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) program.view model dispatch,
-                    document.getElementById(placeholderId)
-                )))
-
-        { program with setState = setState } 
+            match setInternalState with
+            | Some setState ->
+                let render () =
+                    lazyView2With (fun a b -> obj.ReferenceEquals (a, b)) program.view model dispatch
+                setState { render = render }
+            | None ->
+                failwith "withReact init failed."
+        let props =  { getInternalSetState=(fun setState -> setInternalState <- Some setState) }
+        let app = AppComponents.app props []
+        ReactDom.render(
+            app, Browser.document.getElementById(placeholderId)
+        )
+        { program with setState = setState }


### PR DESCRIPTION
Fix https://github.com/fable-elmish/elmish/issues/60

This issue has been fixed in react long long  ago, but it appears in elmish-react now. If we using setState to update the input's value, it won't reset the cursor, because the real input's value after typing is the same as react vdom's, so react won't change the real dom, and cursor won't change. But if we update the view by `ReactDOM.render`, this issue occurred again, so I think we could change to the commonly used way (update the view by setState) in react to keep the consistency.

Warning: this is a breaking change, in the original way, `DefaultValue`  can work around it just like `Value` in this new way, if you change `DefaultValue` in model, it would update the view, too. But now, `DefaultValue` is the `default value`, and won't sync to view if the view is not first render. If you need to control the input, you should using `Value` instead, which is the same as in normal react app.