### PR TITLE
Add installation docs for react-dom to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ As with any JS dependency, if you are authoring an application (as opposed to a 
 
 ```shell
 yarn add react
+yarn add react-dom
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,5 @@ paket add nuget Fable.Elmish.React
 As with any JS dependency, if you are authoring an application (as opposed to a library), you'll also need to install React (separately, via `npm` or `yarn`):
 
 ```shell
-yarn add react
-yarn add react-dom
+yarn add react react-dom
 ```


### PR DESCRIPTION
Without it, following described steps ends with

```
ERROR in C:/Users/n635925/.nuget/packages/fable.elmish.react/1.0.0/fable/react.fs
Module not found: Error: Can't resolve 'react-dom' in 'C:\Users\n635925\.nuget\packages\fable.elmish.react\1.0.0\fable'
 @ C:/Users/n635925/.nuget/packages/fable.elmish.react/1.0.0/fable/react.fs 2:0-35
 @ ./src/App.fs
 @ ./src/ExampleApp.fsproj
 @ multi (webpack)-dev-server/client?http://localhost:8080 ./src/ExampleApp.fsproj
webpack: Failed to compile.
```

Maybe it is sufficient to just call `yarn add react-dom`, which would pull react as a dependency, but I don't know yarn well enough (well I started using it few minutes ago) to verify that.