### PR TITLE
Add React installation instructions to web docs

### DIFF
--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -29,6 +29,12 @@ Elmish-React implements boilerplate to wire up the rendering of React and React 
 paket add nuget Fable.Elmish.React
 ```
 
+You also need to install React:
+
+```shell
+yarn add react react-dom
+```
+
 ## Program module extensions
 Both React and React Native applications need a root component to be rendered at the specified placeholder, see
 [browser](./browser.html) and [native](./native.html) tutorials for details.


### PR DESCRIPTION
This might seem obvious, but it really isn't for a newcommer. Note that this is mentioned in README.md in source code.

I skipped mention about only needing to install react when you create app as opposed to library, because I guess 99% of users are creating the app and those who create a library know what they are doing.