### PR TITLE
Fixes #48 - align browser sample with current API

### DIFF
--- a/docs/content/browser.fsx
+++ b/docs/content/browser.fsx
@@ -58,7 +58,7 @@ Now we need to tell React to render our view in the div placeholder we defined i
 by augumenting our program instance and passing the placeholder id:
 *)
 
-open Elmish.HMR
+open Elmish.React
 
 Program.mkSimple init update view
 |> Program.withReactBatched "elmish-app"

--- a/docs/content/browser.fsx
+++ b/docs/content/browser.fsx
@@ -37,15 +37,16 @@ Let's open React bindings and define our view using them:
 
 *)
 
+open Fable.React
 open Fable.React.Props
-module R = Fable.React
+
 
 let view model dispatch =
 
-  R.div []
-      [ R.button [ OnClick (fun _ -> dispatch Decrement) ] [ R.str "-" ]
-        R.div [] [ R.str (sprintf "%A" model) ]
-        R.button [ OnClick (fun _ -> dispatch Increment) ] [ R.str "+" ] ]
+    div []
+        [ button [ OnClick(fun _ -> dispatch Decrement) ] [ str "-" ]
+          div [] [ str (sprintf "%A" model) ]
+          button [ OnClick(fun _ -> dispatch Increment) ] [ str "+" ] ]
 
 (**
 ### Create the program instance
@@ -57,10 +58,10 @@ Now we need to tell React to render our view in the div placeholder we defined i
 by augumenting our program instance and passing the placeholder id:
 *)
 
-open Elmish.React
+open Elmish.HMR
 
 Program.mkSimple init update view
-|> Program.withReact "elmish-app"
+|> Program.withReactBatched "elmish-app"
 |> Program.run
 
 (**


### PR DESCRIPTION
Wasn't able to test doc building. Don't think I broke anything, fails the same way from the current tree. But can't be sure this is correct. BTW, looks like the fake script is referencing a non existing docpage.cshtml. Replacing it with template.cshtml didn't work, and I ran out of ideas.

`fake run build.fsx -t GenerateDocs`
![image](https://user-images.githubusercontent.com/2453277/84993091-b6bbb680-b140-11ea-961e-27ec8bc06760.png)
