### PR TITLE
Support React 18

### DIFF
--- a/src/Fable.Elmish.React.fsproj
+++ b/src/Fable.Elmish.React.fsproj
@@ -13,6 +13,6 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.*" />
     <PackageReference Include="Fable.Elmish" Version="4.0.0-beta-*" />
-    <PackageReference Include="Fable.React" Version="6.*" />
+    <PackageReference Include="Fable.React" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/src/react.fs
+++ b/src/react.fs
@@ -15,42 +15,77 @@ module Program =
 
     module Internal =
 
+        open Fable.Core
         open Fable.React
         open Browser
         open Elmish
 
-        let withReactBatchedUsing lazyView2With placeholderId (program:Program<_,_,_,_>) =
-            let mutable lastRequest = None
-            let setState model dispatch =
-                match lastRequest with
-                | Some r -> window.cancelAnimationFrame r
-                | _ -> ()
+        [<Import("version", "react")>]
+        let version = jsNative<string>
 
-                lastRequest <- Some (window.requestAnimationFrame (fun _ ->
-                    ReactDom.render(
-                        lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program) model dispatch,
-                        document.getElementById placeholderId
-                    )))
+        // Use the new rendering API in React 18+
+        let useRootApi = try int version.[ .. 1 ] >= 18 with _ -> false
+
+        let withReactBatchedUsing lazyView2With placeholderId (program:Program<_,_,_,_>) =
+            let setState =
+                let mutable lastRequest = None
+
+                if useRootApi then
+                    let root = ReactDomClient.createRoot (document.getElementById placeholderId)
+
+                    fun model dispatch ->
+                        match lastRequest with
+                        | Some r -> window.cancelAnimationFrame r
+                        | _ -> ()
+
+                        lastRequest <- Some (window.requestAnimationFrame (fun _ ->
+                            root.render (lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program) model dispatch)))
+                else
+                    fun model dispatch ->
+                        match lastRequest with
+                        | Some r -> window.cancelAnimationFrame r
+                        | _ -> ()
+
+                        lastRequest <- Some (window.requestAnimationFrame (fun _ ->
+                            ReactDom.render(
+                                lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program) model dispatch,
+                                document.getElementById placeholderId
+                            )))
 
             program
             |> Program.withSetState setState
 
         let withReactSynchronousUsing lazyView2With placeholderId (program:Elmish.Program<_,_,_,_>) =
-            let setState model dispatch =
-                ReactDom.render(
-                    lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program) model dispatch,
-                    document.getElementById placeholderId
-                )
+            let setState =
+                if useRootApi then
+                    let root = ReactDomClient.createRoot (document.getElementById placeholderId)
+
+                    fun model dispatch ->
+                        root.render (lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program) model dispatch)
+                else
+                    fun model dispatch ->
+                        ReactDom.render(
+                            lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program) model dispatch,
+                            document.getElementById placeholderId
+                        )
 
             program
             |> Program.withSetState setState
 
         let withReactHydrateUsing lazyView2With placeholderId (program:Elmish.Program<_,_,_,_>) =
-            let setState model dispatch =
-                ReactDom.hydrate(
-                    lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program) model dispatch,
-                    document.getElementById placeholderId
-                )
+            let setState =
+                if useRootApi then
+                    fun model dispatch ->
+                        ReactDomClient.hydrateRoot (
+                            document.getElementById placeholderId,
+                            lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program) model dispatch
+                        )
+                else
+                    fun model dispatch ->
+                        ReactDom.hydrate(
+                            lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program) model dispatch,
+                            document.getElementById placeholderId
+                        )
 
             program
             |> Program.withSetState setState


### PR DESCRIPTION
Been using this version of `withReactSynchronous` for a few days, works fine. However, you do get a warning when HMR triggers

```
Warning: You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before. Instead, call root.render() on the existing root instead if you want to update it.
```

I don't know the HMR mechanism, so no idea how to fix that - the warning appears benign though.

Thanks to the version check backwards compatibility is preserved.

@forki, if this doesn't work for your SSR project, can you please create a minimal sample repo for me?