### PR TITLE
Use Fable.React.Types dependency

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -48,7 +48,8 @@ Target.create "Build" (fun _ ->
 
 let release = ReleaseNotes.load "RELEASE_NOTES.md"
 
-Target.create "Meta" (fun _ -> $"""
+Target.create "Meta" (fun _ ->
+    $"""
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)/docs/static/img/logo.png" Pack="true" PackagePath="\" />
@@ -61,7 +62,7 @@ Target.create "Meta" (fun _ -> $"""
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Description>Elmish extensions for writing Fable apps with React and ReactNative</Description>
     <PackageProjectUrl>http://{gitOwner}.github.io/{gitName}</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>logo.png</PackageIcon>
     <RepositoryUrl>{gitHome}/{gitName}</RepositoryUrl>

--- a/build.fsx
+++ b/build.fsx
@@ -48,27 +48,30 @@ Target.create "Build" (fun _ ->
 
 let release = ReleaseNotes.load "RELEASE_NOTES.md"
 
-Target.create "Meta" (fun _ ->
-    [ "<Project xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">"
-      "<ItemGroup>"
-      "<None Include=\"../docs/static/img/logo.png\" Pack=\"true\" PackagePath=\"\\\"/>"
-      "<PackageReference Include=\"Microsoft.SourceLink.GitHub\" Version=\"1.0.0\" PrivateAssets=\"All\"/>"
-      "</ItemGroup>"
-      "<PropertyGroup>"
-      "<EmbedUntrackedSources>true</EmbedUntrackedSources>"
-      "<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>"
-      "<Description>Elmish extensions for writing Fable apps with React and ReactNative</Description>"
-      sprintf "<PackageProjectUrl>http://%s.github.io/%s</PackageProjectUrl>" gitOwner gitName
-      "<PackageLicenseUrl>https://raw.githubusercontent.com/elmish/react/master/LICENSE.md</PackageLicenseUrl>"
-      "<PackageIconUrl>https://raw.githubusercontent.com/elmish/elmish/master/docs/files/img/logo.png</PackageIconUrl>"
-      "<PackageIcon>logo.png</PackageIcon>"
-      sprintf "<RepositoryUrl>%s/%s</RepositoryUrl>" gitHome gitName
-      "<PackageTags>fable;elmish;fsharp;React;React-Native</PackageTags>"
-      sprintf "<PackageReleaseNotes>%s</PackageReleaseNotes>" (List.head release.Notes)
-      "<Authors>Eugene Tolmachev</Authors>"
-      sprintf "<Version>%s</Version>" (string release.SemVer)
-      "</PropertyGroup>"
-      "</Project>"]
+Target.create "Meta" (fun _ -> $"""
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)/docs/static/img/logo.png" Pack="true" PackagePath="\" />
+    <None Include="$(MSBuildThisFileDirectory)/LICENSE.md" Pack="true" PackagePath="\" />
+    <None Include="$(MSBuildThisFileDirectory)/README.md" Pack="true" PackagePath="\"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+  </ItemGroup>
+  <PropertyGroup>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Description>Elmish extensions for writing Fable apps with React and ReactNative</Description>
+    <PackageProjectUrl>http://{gitOwner}.github.io/{gitName}</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>logo.png</PackageIcon>
+    <RepositoryUrl>{gitHome}/{gitName}</RepositoryUrl>
+    <PackageTags>fable;elmish;fsharp;React;React-Native</PackageTags>
+    <PackageReleaseNotes>{List.head release.Notes}</PackageReleaseNotes>
+    <Authors>Eugene Tolmachev</Authors>
+    <Version>{string release.SemVer}</Version>
+  </PropertyGroup>
+</Project>"""
+    |> List.singleton
     |> File.write false "Directory.Build.props"
 )
 

--- a/src/Fable.Elmish.React.fsproj
+++ b/src/Fable.Elmish.React.fsproj
@@ -13,6 +13,6 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.*" />
     <PackageReference Include="Fable.Elmish" Version="4.0.0-beta-*" />
-    <PackageReference Include="Fable.React.Types" Version="18.0.0-beta-002" />
+    <PackageReference Include="Fable.React.Types" Version="18.*" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Elmish.React.fsproj
+++ b/src/Fable.Elmish.React.fsproj
@@ -13,6 +13,6 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.*" />
     <PackageReference Include="Fable.Elmish" Version="4.0.0-beta-*" />
-    <PackageReference Include="Fable.React" Version="8.*" />
+    <PackageReference Include="Fable.React.Types" Version="18.0.0-beta-002" />
   </ItemGroup>
 </Project>

--- a/src/common.fs
+++ b/src/common.fs
@@ -3,6 +3,17 @@ namespace Elmish.React
 open Fable.React
 open Elmish
 
+module Internal =
+    open Browser.Types
+    open Fable.Core.JsInterop
+
+    let inline ofType<'T,'P,'S when 'T :> Component<'P,'S>> (props: 'P) (children: ReactElement seq): ReactElement =
+        ReactBindings.React.createElement(jsConstructor<'T>, props, children)
+
+    let updateInputValue (value: string) (e: HTMLInputElement) =
+        if not(isNull e) && e.value <> value then
+            e.value <- value
+
 type LazyProps<'model> = {
     model:'model
     render:unit->ReactElement
@@ -21,6 +32,7 @@ module Components =
 
 [<AutoOpen>]
 module Common =
+
     /// Avoid rendering the view unless the model has changed.
     /// equal: function to compare the previous and the new states
     /// view: function to render the model
@@ -28,7 +40,7 @@ module Common =
     let lazyViewWith (equal:'model->'model->bool)
                      (view:'model->ReactElement)
                      (state:'model) =
-        ofType<Components.LazyView<_>,_,_>
+        Internal.ofType<Components.LazyView<_>,_,_>
             { render = fun () -> view state
               equal = equal
               model = state }
@@ -43,7 +55,7 @@ module Common =
                       (view:'model->'msg Dispatch->ReactElement)
                       (state:'model)
                       (dispatch:'msg Dispatch) =
-        ofType<Components.LazyView<_>,_,_>
+        Internal.ofType<Components.LazyView<_>,_,_>
             { render = fun () -> view state dispatch
               equal = equal
               model = state }
@@ -56,7 +68,7 @@ module Common =
     /// state2: new state to render
     /// dispatch: dispatch function
     let lazyView3With (equal:_->_->bool) (view:_->_->_->ReactElement) state1 state2 (dispatch:'msg Dispatch) =
-        ofType<Components.LazyView<_>,_,_>
+        Internal.ofType<Components.LazyView<_>,_,_>
             { render = fun () -> view state1 state2 dispatch
               equal = equal
               model = (state1,state2) }

--- a/src/react.fs
+++ b/src/react.fs
@@ -2,13 +2,13 @@ namespace Elmish.React
 
 [<AutoOpen>]
 module Helpers =
-    open Fable.React.Props
+    open Fable.React
     open Fable.Core.JsInterop
 
     /// `Ref` callback that sets the value of an input textbox after DOM element is created.
     /// Can be used instead of `DefaultValue` and `Value` props to override input box value.
-    let inline valueOrDefault value =
-        Ref <| (fun e -> if e |> isNull |> not && !!e?value <> !!value then e?value <- !!value)
+    let inline valueOrDefault (value: string): IHTMLProp =
+        !!("ref", Internal.updateInputValue value)
 
 [<RequireQualifiedAccess>]
 module Program =


### PR DESCRIPTION
@et1975 @MangelMaxime With the release of Fable 4, users will have to update some packages so it's a good time to do some cleanup (we should also take the chance to release Elmish 4 as stable). We've been discussing for some time to split Fable.React into a types package containing only bindings (as with the Browser packages) and another containing the helpers. This prevents that packages like Feliz need to take the full Fable.React dependency only for compatibility.

Are you ok with this change? If so, would it be possible to push a beta release? Thanks a lot!

**Note**: I've also tried to improve the project metadata for publishing by using string interpolation in the build script, replace the deprecated tags (PackageIconUrl, PackageLicenceUrl) and add the README file, but I'm not sure if it works correctly. Could you please check?