### PR TITLE
Add Fable.ReactDom.Types dependency

### DIFF
--- a/src/Fable.Elmish.React.fsproj
+++ b/src/Fable.Elmish.React.fsproj
@@ -13,6 +13,6 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.*" />
     <PackageReference Include="Fable.Elmish" Version="4.0.0-beta-*" />
-    <PackageReference Include="Fable.React.Types" Version="18.*" />
+    <PackageReference Include="Fable.ReactDom.Types" Version="18.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Sorry for the last-minute change, but as discussed with @MangelMaxime [here](https://github.com/fable-compiler/fable-react/pull/171#issuecomment-1255721818), given that we're introducing a breaking change in Fable.React, we're taking the opportunity to also put the bindings for react and react-dom in different libraries. Because elmish/react depends on the react-dom bindings it needs to have the new Fable.ReactDom.Types dependency.